### PR TITLE
Setting max-width and overflow properties on div#img_name

### DIFF
--- a/app/static/css/bootstrap.css
+++ b/app/static/css/bootstrap.css
@@ -7096,3 +7096,8 @@ td.visible-print {
     display: none !important;
   }
 }
+
+div#img_name {
+	max-width: 298px;
+	overflow: hidden;
+}


### PR DESCRIPTION
Proposed fix for issue #1, sans the suggestion for any mechanism to display the full file name.
